### PR TITLE
allow faster typing after popups

### DIFF
--- a/app/popup.html
+++ b/app/popup.html
@@ -11,10 +11,10 @@
             <span><a href="#" id="settings">Settings</a></span>
         </div>
   
-        <div id="inputForm">
+        <form id="inputForm" action="javascript:saveData()" method="">
             <input class="textBox" id="inputval" type="text" maxlength="50"/>
             <button id="submit" onclick="saveData();">Create</button>
-        </div>
+        </form>
  
        <p id="confirmation"></p> 
 

--- a/app/scripts/popup.js
+++ b/app/scripts/popup.js
@@ -29,3 +29,11 @@ var openSettings = function() {
 
 document.querySelector('#submit').addEventListener('click', saveData);
 document.querySelector('#settings').addEventListener('click', openSettings);
+
+// Focus on the text box for immediate typing. We have to set a timeout because
+// without one the focus change doesn't take. It seems like this is because the
+// popup isn't completely rendered when we're trying to act on it. This 100ms
+// timeout feels instantaneous to the user but lets the page render first.
+setTimeout(function foo() {
+  document.getElementById('inputval').focus();
+}, 100);


### PR DESCRIPTION
Allows Enter to create the redirect and moves focus to the
text box immediately after opening the popup.
